### PR TITLE
Switch to org.gnome.Platform for WebKitGTK dep

### DIFF
--- a/com.amazon.Workspaces.json
+++ b/com.amazon.Workspaces.json
@@ -1,8 +1,8 @@
 {
     "app-id": "com.amazon.Workspaces",
-    "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
-    "sdk": "org.freedesktop.Sdk",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.36",
+    "sdk": "org.gnome.Sdk",
     "command": "workspacesclient",
     "tags": [
         "proprietary"


### PR DESCRIPTION
While the program starts up with org.freedesktop.Platform, it hits a
runtime error after entering a registration code:

System.DllNotFoundException: Unable to load shared library
'libwebkit2gtk-4.0.so.37' or one of its dependencies. In order to help
diagnose loading problems, consider setting the LD_DEBUG environment
variable: liblibwebkit2gtk-4.0.so.37: cannot open shared object file: No
such file or directory

org.gnome.Plaform contains the needed WebKitGTK library, so use that.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>