### PR TITLE
Remove remote icon

### DIFF
--- a/com.amazon.Workspaces.desktop
+++ b/com.amazon.Workspaces.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=Amazon WorkSpaces
+Comment=Amazon WorkSpace Client
+Exec=/app/bin/workspacesclient %u
+Icon=com.amazon.Workspaces
+Terminal=false
+MimeType=x-scheme-handler/workspaces;
+Categories=Network;RemoteAccess;
+Keywords=workspaces;remote;amazon;aws;
+StartupWMClass=workspacesclient

--- a/com.amazon.Workspaces.json
+++ b/com.amazon.Workspaces.json
@@ -19,12 +19,14 @@
             "name": "workspacesclient",
             "buildsystem": "simple",
             "build-commands": [
-                "mkdir -p /app/bin /app/lib",
-                "install apply_extra /app/bin",
-                "install -Dm644 com.amazon.Workspaces.metainfo.xml /app/share/metainfo/com.amazon.Workspaces.metainfo.xml",
-                "cp /usr/bin/ar /usr/bin/desktop-file-install /app/bin",
-                "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib",
-                "ln -s /app/extra/bin/workspacesclient /app/bin/workspacesclient"
+                "mkdir -p ${FLATPAK_DEST}/bin ${FLATPAK_DEST}/lib",
+                "install apply_extra ${FLATPAK_DEST}/bin",
+                "install -Dm644 -t ${FLATPAK_DEST}/share/metainfo/ ${FLATPAK_ID}.metainfo.xml",
+                "install -Dm644 -t ${FLATPAK_DEST}/share/applications/ ${FLATPAK_ID}.desktop",
+                "install -Dm644 -t ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/ ${FLATPAK_ID}.svg",
+                "cp /usr/bin/ar ${FLATPAK_DEST}/bin",
+                "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so ${FLATPAK_DEST}/lib",
+                "ln -s ${FLATPAK_DEST}/extra/bin/workspacesclient ${FLATPAK_DEST}/bin/workspacesclient"
             ],
             "sources": [
                 {
@@ -35,10 +37,7 @@
                         "tar xf data.tar.xz ./usr ./opt",
                         "rm -f data.tar.xz",
                         "mv opt/workspacesclient ./bin",
-                        "install -Dm644 usr/share/pixmaps/com.amazon.workspaces.svg export/share/icons/hicolor/scalable/apps/com.amazon.Workspaces.svg",
-                        "install -Dm644 usr/share/applications/workspacesclient.desktop export/share/applications/com.amazon.Workspaces.desktop",
-                        "rm -rf usr opt",
-                        "desktop-file-install --dir=/app/extra/export/share/applications --set-key=Exec --set-value=/app/bin/workspacesclient --remove-key=Path --set-icon=com.amazon.Workspaces /app/extra/export/share/applications/com.amazon.Workspaces.desktop"
+                        "rm -rf usr opt"
                     ]
                 },
                 {
@@ -61,6 +60,14 @@
                 {
                     "type": "file",
                     "path": "com.amazon.Workspaces.metainfo.xml"
+                },
+                {
+                    "type": "file",
+                    "path": "com.amazon.Workspaces.svg"
+                },
+                {
+                    "type": "file",
+                    "path": "com.amazon.Workspaces.desktop"
                 }
             ]
         }

--- a/com.amazon.Workspaces.metainfo.xml
+++ b/com.amazon.Workspaces.metainfo.xml
@@ -20,8 +20,6 @@
       <image type="source" width="1136" height="799">https://lh3.googleusercontent.com/CLOzQZjhT7BVay7EzrMLoZuXcceovVBjprBW-LUtlRvVxaPExw3QOIKu_2fyIrfqzog=w1600-h799</image>
     </screenshot>
   </screenshots>
-  <icon type="remote" height="64" width="64">https://lh3.googleusercontent.com/gRCd2qBYLkMNjziqrfixPFmStV4gRpWkkhCW2ooBQtLRr03c6XdCQ9NwNsel2EtQAsU=s64</icon>
-  <icon type="remote" height="128" width="128">https://lh3.googleusercontent.com/gRCd2qBYLkMNjziqrfixPFmStV4gRpWkkhCW2ooBQtLRr03c6XdCQ9NwNsel2EtQAsU=s128</icon>
   <releases>
     <release version="4.2.0.1665" date="2022-08-25"/>
     <release version="4.1.0.1523" date="2022-04-14"/>

--- a/com.amazon.Workspaces.svg
+++ b/com.amazon.Workspaces.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 512 512" xml:space="preserve">
+  <style type="text/css">
+    .st0{fill:#F47F62;}
+    .st1{fill:#BF5248;}
+    .st2{fill:#FBC4AF;}
+    .st3{fill:none;}
+    .st4{fill:#822826;}
+  </style>
+  <g transform="matrix(1.7655 0 0 1.7655 -363.87 -361.93)">
+    <polygon class="st0" points="496.1 297.4 387.5 360.1 441.8 391.4 496.1 422.8" fill="#f47f62"/>
+    <polygon class="st1" points="496.1 422.8 441.8 391.4 387.5 360.1 387.5 485.5" fill="#bf5248"/>
+    <polygon class="st2" points="387.5 360.1 496.1 297.4 387.5 234.7 350.2 256.2 350.2 338.5" fill="#fbc4af"/>
+    <polygon class="st0" points="350.2 338.5 350.2 338.5 278.9 379.7 278.9 422.8 387.5 485.5 387.5 360.1" fill="#f47f62"/>
+    <polygon class="st0" points="278.9 297.4 350.2 338.5 350.2 256.2" fill="#f47f62"/>
+    <polygon class="st1" points="350.2 338.5 350.2 338.5 278.9 297.4 278.9 379.7" fill="#bf5248"/>
+    <polygon class="st3" points="206.1 255.7 241.7 276.2 241.7 276.3 241.8 276.3" fill="none"/>
+    <polygon class="st0" points="313 235.2 277.3 214.5 206.1 255.7 241.8 276.3" fill="#f47f62"/>
+    <polygon class="st1" points="241.7 276.3 241.7 276.2 206.1 255.7 206.1 337.9 241.7 358.5" fill="#bf5248"/>
+    <polygon class="st4" points="241.7 358.5 206.1 255.7 206.1 337.9" fill="#822826"/>
+  </g>
+</svg>


### PR DESCRIPTION
Relates to https://github.com/flathub/com.amazon.Workspaces/issues/25

As discussed in #flatpak remote icons will be blocked on CI level soon, so switching them to local.

Also this will make the Flathub website use a higher res icon than 64px. I used the 512px svg icon from the deb to avoid conversion.