### PR TITLE
Update Amazon Workspaces to 4.6.0.4187

### DIFF
--- a/com.amazon.Workspaces.desktop
+++ b/com.amazon.Workspaces.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Encoding=UTF-8
 Name=Amazon WorkSpaces
-Comment=Amazon WorkSpace Client
+Comment=Amazon WorkSpaces
 Exec=/app/bin/workspacesclient %u
 Icon=com.amazon.Workspaces
 Terminal=false

--- a/com.amazon.Workspaces.json
+++ b/com.amazon.Workspaces.json
@@ -17,7 +17,7 @@
     "modules": [
         "shared-modules/libusb/libusb.json",
         {
-            "name": "hiredis0.13",
+            "name": "hiredis0.14",
             "buildsystem": "simple",
             "build-commands": [
                 "make PREFIX=/app install"
@@ -26,13 +26,53 @@
                 {
                     "type": "git",
                     "url": "https://github.com/redis/hiredis.git",
-                    "tag": "v0.13.3",
-                    "commit": "010756025e8cefd1bc66c6d4ed3b1648ef6f1f95"
+                    "tag": "v0.14.1",
+                    "commit": "f9717aed445547c8ab11a3a4117f648c06e62b56"
                 }
             ],
             "cleanup": [
                 "/include",
                 "/lib/pkgconfig"
+            ]
+        },
+        {
+            "name": "icu63",
+            "buildsystem": "simple",
+            "build-commands": [
+                "cd source && ./configure --prefix=${FLATPAK_DEST} --sbindir=${FLATPAK_DEST}/bin --disable-tests --disable-samples && make -j $FLATPAK_BUILDER_N_JOBS install"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/unicode-org/icu/releases/download/release-63-2/icu4c-63_2-src.tgz",
+                    "sha256": "4671e985b5c11252bff3c2374ab84fd73c609f2603bb6eb23b8b154c69ea4215"
+                }
+            ],
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/icu",
+                "/lib/libicutest.so*",
+                "/lib/libicutu.so*",
+                "/share/icu",
+                "/share/man"
+            ]
+        },
+        {
+            "name": "graphicsmagick",
+            "builddir": true,
+            "config-opts": [
+                "--enable-shared"
+            ],
+            "cleanup": [
+                "/bin/GraphicsMagick*config"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.40/GraphicsMagick-1.3.40.tar.xz",
+                    "sha256": "97dc1a9d4e89c77b25a3b24505e7ff1653b88f9bfe31f189ce10804b8efa7746"
+                }
             ]
         },
         {
@@ -66,14 +106,14 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/bionic/main/binary-amd64/workspacesclient_4.5.0.4198_amd64.deb",
-                    "size": 28547732,
-                    "sha256": "033f5a4bd483ab33c3b1257e76df4d37f49ab7e0cda2137a3e860e6e665f0401",
+                    "url": "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/focal/main/binary-amd64/workspacesclient_4.6.0.4187_amd64.deb",
+                    "size": 28598808,
+                    "sha256": "03e6fbf5ec21e210487fc8e02b420d20b164b53a914693a05d11f4146ce257a7",
                     "x-checker-data": {
                         "type": "debian-repo",
                         "package-name": "workspacesclient",
                         "root": "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu",
-                        "dist": "bionic",
+                        "dist": "focal",
                         "component": "main"
                     }
                 },

--- a/com.amazon.Workspaces.metainfo.xml
+++ b/com.amazon.Workspaces.metainfo.xml
@@ -21,6 +21,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="4.6.0.4187" date="2023-06-20"/>
     <release version="4.5.0.4198" date="2023-06-21"/>
     <release version="4.4.0.1997" date="2022-12-27"/>
     <release version="4.3.0.1766" date="2022-10-05"/>


### PR DESCRIPTION
 - Update hiredis to 0.14.1. Dependency as per control file
 - Add icu63 to resolve `Process terminated. Couldn't find a valid ICU package installed on the system. Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support`
 - Add graphicsmagick. Dependency as per control file
 - Change deb branch to focal

A bit late since I didn't realise there was a different deb dist.